### PR TITLE
Fix: Merged the rubocop matrics duplication in config

### DIFF
--- a/server/.rubocop.yml
+++ b/server/.rubocop.yml
@@ -26,6 +26,7 @@ Metrics/BlockLength:
   Max: 50
   Exclude:
     - 'config/routes/api.rb'  # If your routes are separated for API, else keep 'config/routes.rb'
+    - 'spec/**/*.rb'
 
 Metrics/AbcSize:
   Max: 50
@@ -67,11 +68,6 @@ Style/Documentation:
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
-
-# Exclude specs from certain checks
-Metrics/BlockLength:
-  Exclude:
-    - 'spec/**/*.rb'
 
 Metrics/ClassLength:
   Max: 120 # or an appropriate number for your project


### PR DESCRIPTION
This PR removes the duplicated the rubocop matric from `rubocop.yml`.