### PR TITLE
fix: remove disable condition for adding more mapping

### DIFF
--- a/ui/src/views/Activate/Syncs/EditSync/EditSync.tsx
+++ b/ui/src/views/Activate/Syncs/EditSync/EditSync.tsx
@@ -202,6 +202,7 @@ const EditSync = (): JSX.Element | null => {
                   data={configuration}
                   isEdit
                   configuration={configuration}
+                  stream={selectedStream}
                 />
               ) : (
                 <MapFields

--- a/ui/src/views/Activate/Syncs/SyncForm/ConfigureSyncs/ConfigureSyncs.tsx
+++ b/ui/src/views/Activate/Syncs/SyncForm/ConfigureSyncs/ConfigureSyncs.tsx
@@ -96,6 +96,7 @@ const ConfigureSyncs = ({
               destination={selectedDestination}
               handleOnConfigChange={handleOnConfigChange}
               configuration={configuration}
+              stream={selectedStream}
             />
           ) : (
             <MapFields

--- a/ui/src/views/Activate/Syncs/SyncForm/ConfigureSyncs/FieldMap.tsx
+++ b/ui/src/views/Activate/Syncs/SyncForm/ConfigureSyncs/FieldMap.tsx
@@ -80,7 +80,13 @@ const FieldMap = ({
             disabledOptions={disabledOptions}
           />
         ) : fieldType === 'custom' ? (
-          <Input value={value} onChange={(e) => onChange(id, fieldType, e.target.value)} />
+          <Input
+            value={value}
+            onChange={(e) => onChange(id, fieldType, e.target.value)}
+            isDisabled={isDisabled}
+            borderColor={isDisabled ? 'gray.500' : 'gray.400'}
+            backgroundColor={isDisabled ? 'gray.300' : 'gray.100'}
+          />
         ) : (
           <TemplateMapping
             entityName={entityName}

--- a/ui/src/views/Activate/Syncs/SyncForm/ConfigureSyncs/MapCustomFields.tsx
+++ b/ui/src/views/Activate/Syncs/SyncForm/ConfigureSyncs/MapCustomFields.tsx
@@ -3,7 +3,7 @@ import { ModelEntity } from '@/views/Models/types';
 import { Box, Button, CloseButton, Text } from '@chakra-ui/react';
 import { getModelPreviewById } from '@/services/models';
 import { useQuery } from '@tanstack/react-query';
-import { FieldMap as FieldMapType } from '@/views/Activate/Syncs/types';
+import { FieldMap as FieldMapType, Stream } from '@/views/Activate/Syncs/types';
 import FieldMap from './FieldMap';
 import { useEffect, useState } from 'react';
 import { ArrowRightIcon } from '@heroicons/react/24/outline';
@@ -12,6 +12,7 @@ import { OPTION_TYPE } from './TemplateMapping/TemplateMapping';
 type MapCustomFieldsProps = {
   model: ModelEntity;
   destination: ConnectorItem;
+  stream: Stream | null;
   data?: FieldMapType[] | null;
   isEdit?: boolean;
   handleOnConfigChange: (args: FieldMapType[]) => void;
@@ -25,6 +26,7 @@ const MapCustomFields = ({
   isEdit,
   handleOnConfigChange,
   configuration,
+  stream,
 }: MapCustomFieldsProps): JSX.Element | null => {
   const [fields, setFields] = useState<FieldMapType[]>([{ from: '', to: '', mapping_type: '' }]);
   const { data: previewModelData } = useQuery({
@@ -127,7 +129,7 @@ const MapCustomFields = ({
             options={modelColumns}
             disabledOptions={mappedColumns}
             onChange={handleOnChange}
-            isDisabled={false}
+            isDisabled={!stream}
             selectedConfigOptions={configuration}
           />
           <Box width='80px' padding='20px' position='relative' top='8px' color='gray.600'>
@@ -137,7 +139,7 @@ const MapCustomFields = ({
             id={index}
             icon={destination.attributes.icon}
             entityName={destination.attributes.connector_name}
-            isDisabled={false}
+            isDisabled={!stream}
             value={fields[index].to}
             onChange={handleOnChange}
             fieldType='custom'
@@ -165,7 +167,7 @@ const MapCustomFields = ({
           fontWeight={700}
           lineHeight='18px'
           letterSpacing='-0.12px'
-          isDisabled={fields.length === modelColumns.length}
+          isDisabled={!stream}
         >
           Add mapping
         </Button>

--- a/ui/src/views/Activate/Syncs/SyncForm/ConfigureSyncs/MapFields.tsx
+++ b/ui/src/views/Activate/Syncs/SyncForm/ConfigureSyncs/MapFields.tsx
@@ -197,7 +197,7 @@ const MapFields = ({
           fontWeight={700}
           lineHeight='18px'
           letterSpacing='-0.12px'
-          isDisabled={fields.length === modelColumns.length || !stream}
+          isDisabled={!stream}
         >
           Add mapping
         </Button>

--- a/ui/src/views/Connectors/Destinations/DestinationsForm/DestinationConnectionTest/DestinationConnectionTest.tsx
+++ b/ui/src/views/Connectors/Destinations/DestinationsForm/DestinationConnectionTest/DestinationConnectionTest.tsx
@@ -63,7 +63,7 @@ const DestinationConnectionTest = (): JSX.Element | null => {
     refetchOnWindowFocus: false,
   });
 
-  const isAnyFailed = connectionResponse?.connection_status.status !== 'succeeded';
+  const isAnyFailed = connectionResponse?.connection_status?.status !== 'succeeded';
 
   const handleOnContinueClick = () => {
     handleMoveForward(stepInfo?.formKey as string, processedDestinationConfig);
@@ -182,7 +182,7 @@ const DestinationConnectionTest = (): JSX.Element | null => {
                   letterSpacing='-0.14px'
                 >
                   {isAnyFailed
-                    ? connectionResponse?.connection_status.message
+                    ? connectionResponse?.connection_status?.message
                     : `All tests passed. Continue to finish setting up your ${selectedDestination} Source`}
                 </AlertDescription>
               </Box>

--- a/ui/src/views/Connectors/Destinations/DestinationsForm/DestinationConnectionTest/DestinationConnectionTest.tsx
+++ b/ui/src/views/Connectors/Destinations/DestinationsForm/DestinationConnectionTest/DestinationConnectionTest.tsx
@@ -183,7 +183,7 @@ const DestinationConnectionTest = (): JSX.Element | null => {
                 >
                   {isAnyFailed
                     ? connectionResponse?.connection_status?.message
-                    : `All tests passed. Continue to finish setting up your ${selectedDestination} Source`}
+                    : `All tests passed. Continue to finish setting up your ${selectedDestination} Destination`}
                 </AlertDescription>
               </Box>
             </Alert>


### PR DESCRIPTION
## Description
Removed the condition to allow any number of mapping during sync configuration.


https://github.com/Multiwoven/multiwoven/assets/29303618/9de0b697-6329-4289-a8cf-d060ec9cd3bc


## Related Issue


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would impact existing functionality)
- [ ] Styling change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Chore
  
## How Has This Been Tested?
<!-- Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist:
- [x] Ensure a branch name is prefixed with `feature`, `bugfix`, `hotfix`, `release`, `style` or `chore` followed by `/` and branch name e.g `feature/add-salesforce-connector`
- [ ] Added unit tests for the changes made (if required)
- [x] Have you made sure the commit messages meets the guidelines?
- [x] Added relevant screenshots for the changes
- [x] Have you tested the changes on local/staging?
- [x] Have you made sure the code you have written follows the best practises to the best of your knowledge?
