### PR TITLE
fix: Update sync run mailer to trigger on failure only

### DIFF
--- a/server/app/mailers/sync_run_mailer.rb
+++ b/server/app/mailers/sync_run_mailer.rb
@@ -6,12 +6,11 @@ class SyncRunMailer < ApplicationMailer
   def status_email
     @sync_run = params[:sync_run]
     @sync = @sync_run.sync
-    @sync_status = @sync_run.status
     @source_connector_name = @sync_run.sync.source.name
     @destination_connector_name = @sync_run.sync.destination.name
     host = Rails.configuration.action_mailer.default_url_options[:host]
     @sync_run_url = "#{host}/activate/syncs/#{@sync.id}/run/#{@sync_run.id}"
-    mail(to: params[:recipient], subject: "Sync run status update") do |format|
+    mail(to: params[:recipient], subject: "Sync failure") do |format|
       format.html { render layout: false }
     end
   end

--- a/server/app/models/sync_run.rb
+++ b/server/app/models/sync_run.rb
@@ -28,7 +28,7 @@ class SyncRun < ApplicationRecord
 
   after_initialize :set_defaults, if: :new_record?
   after_discard :perform_post_discard_sync_run
-  after_commit :send_status_email, if: :status_changed_to_success_or_failed?
+  after_commit :send_status_email, if: :status_changed_to_failure?
 
   aasm column: :status, whiny_transitions: true do
     state :pending, initial: true
@@ -107,7 +107,7 @@ class SyncRun < ApplicationRecord
     end
   end
 
-  def status_changed_to_success_or_failed?
-    saved_change_to_status? && (status == "success" || status == "failed")
+  def status_changed_to_failure?
+    saved_change_to_status? && (status == "failed")
   end
 end

--- a/server/app/views/sync_run_mailer/status_email.html.erb
+++ b/server/app/views/sync_run_mailer/status_email.html.erb
@@ -17,23 +17,23 @@
       display: inline-block;
       padding: 10px 20px;
       margin: 20px 0;
-      background-color: <%= @sync_status == "success" ? '#33C0A7' : '#F54C3D' %>;
+      background-color: '#F54C3D';
       color: white;
       text-decoration: none;
       font-weight: bold;
       border-radius: 5px;
     }
     .status {
-      color: <%= @sync_status == "success" ? '#33C0A7' : '#F54C3D' %>;
+      color: '#F54C3D';
       font-weight: bold;
     }
   </style>
 </head>
 <body>
   <div class="email-body">
-    <p><%= @source_connector_name %> to <%= @destination_connector_name %> job was <span class="status"><%= @sync_status == "success" ? "successful" : "failure" %></span>. Please click the Sync Run link below to view more details.</p>
+    <p><%= @source_connector_name %> to <%= @destination_connector_name %> job had a failure. Please click the link below to view details.</p>
     <div class="button-container">
-      <a href="<%= @sync_run_url %>" class="button">Sync Run</a>
+      <a href="<%= @sync_run_url %>" class="button">View Sync Run</a>
     </div>
   </div>
 </body>

--- a/server/spec/mailers/sync_run_mailer_spec.rb
+++ b/server/spec/mailers/sync_run_mailer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe SyncRunMailer, type: :mailer do
     let!(:catalog) { create(:catalog, connector: destination) }
     let(:sync) { create(:sync, source:, destination:) }
     let(:sync_run) do
-      create(:sync_run, sync:, workspace: sync.workspace, source:, destination:, model: sync.model, status: "success")
+      create(:sync_run, sync:, workspace: sync.workspace, source:, destination:, model: sync.model, status: "failed")
     end
     let(:sync_run_pending) do
       create(:sync_run, sync:, workspace: sync.workspace, source:, destination:, model: sync.model, status: "pending")
@@ -20,13 +20,12 @@ RSpec.describe SyncRunMailer, type: :mailer do
     let(:mail) { SyncRunMailer.with(sync_run:, recipient:).status_email }
 
     it "renders the headers" do
-      expect(mail.subject).to eq("Sync run status update")
+      expect(mail.subject).to eq("Sync failure")
       expect(mail.to).to eq([recipient])
       expect(mail.from).to eq(["noreply@multiwoven.com"])
     end
 
     it "renders the body" do
-      expect(mail.body.encoded).to match(sync_run.status)
       expect(mail.body.encoded).to match(sync.source.name)
       expect(mail.body.encoded).to match(sync.destination.name)
       host = Rails.configuration.action_mailer.default_url_options[:host]

--- a/server/spec/models/sync_run_spec.rb
+++ b/server/spec/models/sync_run_spec.rb
@@ -158,12 +158,6 @@ RSpec.describe SyncRun, type: :model do
     let(:sync) { create(:sync, sync_interval: 3, sync_interval_unit: "hours", source:, destination:) }
     let(:sync_run) { create(:sync_run, sync:, status: :pending) }
 
-    it "calls send_status_email after commit when status changes to success" do
-      allow(sync_run).to receive(:send_status_email)
-      sync_run.update!(status: :success)
-      expect(sync_run).to have_received(:send_status_email)
-    end
-
     it "calls send_status_email after commit when status changes to failed" do
       allow(sync_run).to receive(:send_status_email)
       sync_run.update!(status: :failed)


### PR DESCRIPTION
## Description
fix: Update sync run mailer to trigger on failure only

## Related Issue
None

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would impact existing functionality)
- [ ] Documentation update
- [ ] Chore
  
## How Has This Been Tested?
Wrote rspec

## Checklist:
- [x] Ensure a branch name is prefixed with `feature`, `bugfix`, `hotfix`, `release` or `chore` followed by `/` and branch name e.g `feature/add-salesforce-connector`
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
