### PR TITLE
fix: update back button navigation on syncs configuration

### DIFF
--- a/ui/src/views/Activate/Syncs/EditSync/EditSync.tsx
+++ b/ui/src/views/Activate/Syncs/EditSync/EditSync.tsx
@@ -228,6 +228,8 @@ const EditSync = (): JSX.Element | null => {
           isDocumentsSectionRequired
           isContinueCtaRequired
           isBackRequired
+          navigateToListScreen
+          listScreenUrl='/activate/syncs'
         />
       </Box>
     </form>

--- a/ui/src/views/Connectors/Sources/SourcesForm/SourceFormFooter/SourceFormFooter.tsx
+++ b/ui/src/views/Connectors/Sources/SourcesForm/SourceFormFooter/SourceFormFooter.tsx
@@ -16,6 +16,8 @@ type SourceFormFooterProps = {
   isDocumentsSectionRequired?: boolean;
   isAlignToContentContainer?: boolean;
   extra?: JSX.Element;
+  navigateToListScreen?: boolean;
+  listScreenUrl?: string;
 };
 
 const SourceFormFooter = ({
@@ -25,11 +27,13 @@ const SourceFormFooter = ({
   onCtaClick,
   isBackRequired,
   extra,
+  listScreenUrl,
   isCtaLoading = false,
   isCtaDisabled = false,
   isContinueCtaRequired = false,
   isDocumentsSectionRequired = false,
   secondaryCtaText = 'Back',
+  navigateToListScreen = false,
 }: SourceFormFooterProps): JSX.Element => {
   const [leftOffset, setLeftOffet] = useState<number>(0);
   const { maxContentWidth } = useUiConfig();
@@ -93,7 +97,11 @@ const SourceFormFooter = ({
           {extra}
           {isBackRequired ? (
             <Button
-              onClick={() => navigate(-1)}
+              onClick={() =>
+                navigateToListScreen && listScreenUrl
+                  ? navigate(listScreenUrl, { replace: true })
+                  : navigate(-1)
+              }
               marginRight={isContinueCtaRequired ? '10px' : '0'}
               variant='ghost'
               minWidth={0}


### PR DESCRIPTION
## Description
The back button was not navigating to the syncs list screen from the edit page. Fixed the issue


https://github.com/Multiwoven/multiwoven/assets/29303618/9c454694-115d-48dd-bb2f-10021f5f7e40

## Related Issue


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would impact existing functionality)
- [ ] Styling change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Chore
  
## How Has This Been Tested?
<!-- Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist:
- [x] Ensure a branch name is prefixed with `feature`, `bugfix`, `hotfix`, `release`, `style` or `chore` followed by `/` and branch name e.g `feature/add-salesforce-connector`
- [ ] Added unit tests for the changes made (if required)
- [x] Have you made sure the commit messages meets the guidelines?
- [x] Added relevant screenshots for the changes
- [x] Have you tested the changes on local/staging?
- [x] Have you made sure the code you have written follows the best practises to the best of your knowledge?
