### PR TITLE
fix: Remove \n from rendered liquid template data

### DIFF
--- a/server/lib/reverse_etl/transformers/user_mapping.rb
+++ b/server/lib/reverse_etl/transformers/user_mapping.rb
@@ -65,7 +65,7 @@ module ReverseEtl
         template = mapping[:from]
         Liquid::Template.register_filter(Liquid::CustomFilters)
         liquid_template = Liquid::Template.parse(template)
-        rendered_text = liquid_template.render(record)
+        rendered_text = liquid_template.render(record).gsub(/\n/, '')
         extract_destination_mapping(dest_keys, rendered_text)
       end
 

--- a/server/lib/reverse_etl/transformers/user_mapping.rb
+++ b/server/lib/reverse_etl/transformers/user_mapping.rb
@@ -65,7 +65,7 @@ module ReverseEtl
         template = mapping[:from]
         Liquid::Template.register_filter(Liquid::CustomFilters)
         liquid_template = Liquid::Template.parse(template)
-        rendered_text = liquid_template.render(record).gsub(/\n/, '')
+        rendered_text = liquid_template.render(record).gsub(/\n/, "")
         extract_destination_mapping(dest_keys, rendered_text)
       end
 

--- a/server/spec/lib/reverse_etl/transformers/user_mapping_spec.rb
+++ b/server/spec/lib/reverse_etl/transformers/user_mapping_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe ReverseEtl::Transformers::UserMapping do
             from: "{% if cr_reason_sk == '40' %}\nZA\n{% else %}\nPR\n{% endif %}" }
         ]
       end
-    
+
       it "transforms record according to v2 mappings" do
         results = extractor.transform(sync, sync_record)
         expected_result = {
@@ -122,18 +122,18 @@ RSpec.describe ReverseEtl::Transformers::UserMapping do
             "properties" => {
               "cast_filter" => "Transformed 40.0",
               "regex_replace_field" => "Transformed Numbers",
-              "condition_output" => "ZA" 
+              "condition_output" => "ZA"
             }
           }
         }
-    
+
         expect(results).to eq(expected_result)
       end
-    
+
       it "does not include newline characters in condition_output" do
         results = extractor.transform(sync, sync_record)
-        expect(results["attributes"]["properties"]["condition_output"]).to eq("ZA")  # Expecting 'PR' without newline characters
+        expect(results["attributes"]["properties"]["condition_output"]).to eq("ZA")
       end
-    end    
+    end
   end
 end

--- a/server/spec/lib/reverse_etl/transformers/user_mapping_spec.rb
+++ b/server/spec/lib/reverse_etl/transformers/user_mapping_spec.rb
@@ -109,23 +109,31 @@ RSpec.describe ReverseEtl::Transformers::UserMapping do
           { mapping_type: "template", to: "attributes.properties.cast_filter",
             from: "Transformed {{cr_reason_sk  | cast: 'number' }}" },
           { mapping_type: "template", to: "attributes.properties.regex_replace_field",
-            from: "Transformed {{cr_reason_sk | regex_replace: '[0-9]+', 'Numbers'}}" }
+            from: "Transformed {{cr_reason_sk | regex_replace: '[0-9]+', 'Numbers'}}" },
+          { mapping_type: "template", to: "attributes.properties.condition_output",
+            from: "{% if cr_reason_sk == '40' %}\nZA\n{% else %}\nPR\n{% endif %}" }
         ]
       end
-
+    
       it "transforms record according to v2 mappings" do
         results = extractor.transform(sync, sync_record)
         expected_result = {
           "attributes" => {
             "properties" => {
               "cast_filter" => "Transformed 40.0",
-              "regex_replace_field" => "Transformed Numbers"
+              "regex_replace_field" => "Transformed Numbers",
+              "condition_output" => "ZA" 
             }
           }
         }
-
+    
         expect(results).to eq(expected_result)
       end
-    end
+    
+      it "does not include newline characters in condition_output" do
+        results = extractor.transform(sync, sync_record)
+        expect(results["attributes"]["properties"]["condition_output"]).to eq("ZA")  # Expecting 'PR' without newline characters
+      end
+    end    
   end
 end


### PR DESCRIPTION
## Description
fix: Remove \n from rendered liquid template data

## Related Issue
None

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Connector (Destination or Source Connector)
- [ ] Breaking change (fix or feature that would impact existing functionality)
- [ ] Styling change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Chore

## How Has This Been Tested?
Wrote rspec unit tests

## Checklist:

- [x] Ensure a branch name is prefixed with `feature`, `bugfix`, `hotfix`, `release`, `style` or `chore` followed by `/` and branch name e.g `feature/add-salesforce-connector`
- [x] Added unit tests for the changes made (if required)
- [x] Have you made sure the commit messages meets the guidelines?
- [x] Added relevant screenshots for the changes
- [x] Have you tested the changes on local/staging?
- [ ] Added the new connector in rollout.rb
- [ ] Have you updated the version number of the gem?
- [ ] Have you ensured that your changes for new connector are documented in the [docs repo](https://github.com/Multiwoven/docs) or relevant documentation files?
- [ ] Have you updated the run time dependency in multiwoven-integrations.gemspec if new gems are added
- [x] Have you made sure the code you have written follows the best practises to the best of your knowledge?
