### PR TITLE
fix: Add greater than zero validation for sync_interval

### DIFF
--- a/server/app/contracts/sync_contracts.rb
+++ b/server/app/contracts/sync_contracts.rb
@@ -42,6 +42,10 @@ module SyncContracts
     rule(sync: :sync_interval_unit) do
       key.failure("invalid connector type") unless Sync.sync_interval_units.keys.include?(value.downcase)
     end
+
+    rule("sync.sync_interval") do
+      key.failure("must be greater than 0") if value <= 0
+    end
   end
 
   class Update < Dry::Validation::Contract
@@ -72,6 +76,10 @@ module SyncContracts
 
     rule(sync: :sync_interval_unit) do
       key.failure("invalid connector type") if key? && !Sync.sync_interval_units.keys.include?(value.downcase)
+    end
+
+    rule("sync.sync_interval") do
+      key.failure("must be greater than 0") if value <= 0
     end
   end
 

--- a/server/app/models/sync.rb
+++ b/server/app/models/sync.rb
@@ -28,7 +28,7 @@ class Sync < ApplicationRecord
   validates :model_id, presence: true
   validates :configuration, presence: true
   validates :schedule_type, presence: true
-  validates :sync_interval, presence: true
+  validates :sync_interval, presence: true, numericality: { greater_than: 0 }
   validates :sync_interval_unit, presence: true
   validates :stream_name, presence: true
   validates :status, presence: true

--- a/server/spec/contracts/sync_contracts_spec.rb
+++ b/server/spec/contracts/sync_contracts_spec.rb
@@ -65,6 +65,50 @@ RSpec.describe "SyncContracts" do
         expect(result.errors[:sync][:sync_mode]).to include("invalid sync mode")
       end
     end
+
+    context "with non-positive sync_interval" do
+      let(:invalid_inputs) { { sync: valid_inputs[:sync].merge(sync_interval: 0) } }
+
+      it "fails validation" do
+        result = contract.call(invalid_inputs)
+        expect(result.errors[:sync][:sync_interval]).to include("must be greater than 0")
+      end
+    end
+  end
+
+  describe SyncContracts::Update do
+    subject(:contract) { described_class.new }
+
+    let(:valid_inputs) do
+      {
+        id: 1,
+        sync: {
+          source_id: 1,
+          model_id: 2,
+          destination_id: 3,
+          schedule_type: "automated",
+          sync_interval: 15,
+          sync_interval_unit: "hours",
+          sync_mode: "incremental",
+          stream_name: "updated_stream"
+        }
+      }
+    end
+
+    context "with valid inputs" do
+      it "passes validation" do
+        expect(contract.call(valid_inputs)).to be_success
+      end
+    end
+
+    context "with non-positive sync_interval" do
+      let(:invalid_inputs) { { id: 1, sync: valid_inputs[:sync].merge(sync_interval: -1) } }
+
+      it "fails validation" do
+        result = contract.call(invalid_inputs)
+        expect(result.errors[:sync][:sync_interval]).to include("must be greater than 0")
+      end
+    end
   end
 
   describe SyncContracts::Destroy do

--- a/server/spec/models/sync_spec.rb
+++ b/server/spec/models/sync_spec.rb
@@ -314,4 +314,23 @@ RSpec.describe Sync, type: :model do
               hash_including(options: hash_including(workflow_id: a_string_starting_with("terminate-"))))
     end
   end
+
+  describe "validations" do
+    let(:source) do
+      create(:connector, connector_type: "source", connector_name: "Snowflake")
+    end
+    let(:destination) { create(:connector, connector_type: "destination") }
+    let!(:catalog) { create(:catalog, connector: destination) }
+    let(:sync) { build(:sync, sync_interval: 3, sync_interval_unit: "hours", source:, destination:) }
+
+    it "validates that sync_interval is greater than 0" do
+      sync.sync_interval = 0
+      expect(sync).not_to be_valid
+      expect(sync.errors[:sync_interval]).to include("must be greater than 0")
+
+      sync.sync_interval = -1
+      expect(sync).not_to be_valid
+      expect(sync.errors[:sync_interval]).to include("must be greater than 0")
+    end
+  end
 end


### PR DESCRIPTION
## Description
fix: Add greater than zero validation for sync_interval

## Related Issue
None

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Connector (Destination or Source Connector)
- [ ] Breaking change (fix or feature that would impact existing functionality)
- [ ] Styling change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Chore

## How Has This Been Tested?
Wrote rspec unit test

## Checklist:

- [x] Ensure a branch name is prefixed with `feature`, `bugfix`, `hotfix`, `release`, `style` or `chore` followed by `/` and branch name e.g `feature/add-salesforce-connector`
- [x] Added unit tests for the changes made (if required)
- [x] Have you made sure the commit messages meets the guidelines?
- [ ] Added relevant screenshots for the changes
- [x] Have you tested the changes on local/staging?
- [ ] Added the new connector in rollout.rb
- [ ] Have you updated the version number of the gem?
- [ ] Have you ensured that your changes for new connector are documented in the [docs repo](https://github.com/Multiwoven/docs) or relevant documentation files?
- [ ] Have you updated the run time dependency in multiwoven-integrations.gemspec if new gems are added
- [ ] Have you made sure the code you have written follows the best practises to the best of your knowledge?
