### PR TITLE
feat: added skip rows in the sync runs table

### DIFF
--- a/ui/src/views/Activate/Syncs/SyncRuns/SyncRunTableItem.tsx
+++ b/ui/src/views/Activate/Syncs/SyncRuns/SyncRunTableItem.tsx
@@ -23,6 +23,9 @@ export const TableItem = ({ field, data }: TableItem): JSX.Element => {
     case 'duration':
       return <Text fontSize='sm'>{data.attributes.duration?.toPrecision(3)} seconds</Text>;
 
+    case 'skipped_rows':
+      return <Text fontSize='sm'>{data.attributes.skipped_rows} rows</Text>;
+
     case 'rows_queried':
       return <Text fontSize='sm'>{data.attributes.total_query_rows} rows</Text>;
 

--- a/ui/src/views/Activate/Syncs/__tests__/SyncRunsTableItem.test.tsx
+++ b/ui/src/views/Activate/Syncs/__tests__/SyncRunsTableItem.test.tsx
@@ -19,6 +19,7 @@ const mockSyncRunsData: SyncRunsResponse[] = [
       updated_at: '2024-01-01T00:00:00.000Z',
       duration: 1.0,
       total_query_rows: 500,
+      skipped_rows: 0,
       total_rows: 500,
       successful_rows: 500,
       failed_rows: 0,
@@ -39,6 +40,7 @@ const mockSyncRunsData: SyncRunsResponse[] = [
       updated_at: '2024-03-15T07:26:07.378Z',
       duration: 1.0,
       total_query_rows: 500,
+      skipped_rows: 0,
       total_rows: 500,
       successful_rows: 450,
       failed_rows: 50,
@@ -61,6 +63,11 @@ describe('TableItem', () => {
   it('should render rows queried correctly', () => {
     render(<TableItem field='rows_queried' data={mockSyncRunsData[0]} />);
     expect(screen.getByText('500 rows')).toBeTruthy();
+  });
+
+  it('should render rows skipped correctly', () => {
+    render(<TableItem field='skipped_rows' data={mockSyncRunsData[0]} />);
+    expect(screen.getByText('0 rows')).toBeTruthy();
   });
 
   it('should render status correctly for success', () => {

--- a/ui/src/views/Activate/Syncs/constants.ts
+++ b/ui/src/views/Activate/Syncs/constants.ts
@@ -39,6 +39,12 @@ export const SYNC_RUNS_COLUMNS: SyncRunsColumnEntity[] = [
     hoverText: 'Number of rows your query returned from the Source.',
   },
   {
+    key: 'skipped_rows',
+    name: 'Rows Skipped',
+    hasHoverText: true,
+    hoverText: 'Number of rows your query skipped while processing your sync.',
+  },
+  {
     key: 'results',
     name: 'Results',
     hasHoverText: true,

--- a/ui/src/views/Activate/Syncs/types.ts
+++ b/ui/src/views/Activate/Syncs/types.ts
@@ -145,6 +145,7 @@ export type SyncRunsResponse = {
     updated_at: string;
     duration: number | null;
     total_query_rows: number;
+    skipped_rows: number;
     total_rows: number;
     successful_rows: number;
     failed_rows: number;
@@ -159,6 +160,7 @@ export type SyncRunsColumnFields =
   | 'start_time'
   | 'duration'
   | 'rows_queried'
+  | 'skipped_rows'
   | 'results';
 
 export type SyncRunsColumnEntity = {


### PR DESCRIPTION
## Description

Added rows skipped in the sync runs table

<img width="1286" alt="Screenshot 2024-04-23 at 1 31 59 PM" src="https://github.com/Multiwoven/multiwoven/assets/29303618/454171db-35ef-4350-8885-25a282627f85">


## Related Issue

<!-- Link to any related issues or indicate 'None' if applicable e.g
 Relates to issue #123 - 'Enhance the process of fetching destinations details'. If none, state 'None'. -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New Connector (Destination or Source Connector)
- [ ] Breaking change (fix or feature that would impact existing functionality)
- [ ] Styling change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Chore

## How Has This Been Tested?

<!-- Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist:

- [x] Ensure a branch name is prefixed with `feature`, `bugfix`, `hotfix`, `release`, `style` or `chore` followed by `/` and branch name e.g `feature/add-salesforce-connector`
- [x] Added unit tests for the changes made (if required)
- [x] Have you made sure the commit messages meets the guidelines?
- [x] Added relevant screenshots for the changes
- [x] Have you tested the changes on local/staging?
- [ ] Added the new connector in rollout.rb
- [ ] Have you updated the version number of the gem?
- [ ] Have you ensured that your changes for new connector are documented in the [docs repo](https://github.com/Multiwoven/docs) or relevant documentation files?
- [ ] Have you updated the run time dependency in multiwoven-integrations.gemspec if new gems are added
- [x] Have you made sure the code you have written follows the best practises to the best of your knowledge?
