### PR TITLE
Fix/add catalog error in sync stream name exists

### DIFF
--- a/server/app/models/sync.rb
+++ b/server/app/models/sync.rb
@@ -146,11 +146,15 @@ class Sync < ApplicationRecord
 
   def stream_name_exists?
     return if destination.blank?
+    byebug
+    if destination.catalog.blank?
+        errors.add(:catalog,"Catalog is missing")
+    else
+        stream = destination.catalog.find_stream_by_name(stream_name)
+        return if stream.present?
 
-    stream = destination.catalog.find_stream_by_name(stream_name)
-    return if stream.present?
-
-    errors.add(:stream_name,
-               "Add a valid stream_name associated with destination connector")
+        errors.add(:stream_name,
+                   "Add a valid stream_name associated with destination connector")
+    end
   end
 end

--- a/server/app/models/sync.rb
+++ b/server/app/models/sync.rb
@@ -146,7 +146,6 @@ class Sync < ApplicationRecord
 
   def stream_name_exists?
     return if destination.blank?
-    byebug
     if destination.catalog.blank?
         errors.add(:catalog,"Catalog is missing")
     else


### PR DESCRIPTION
## Description

Currently, if we don't create a catalog for the connector before creating the sync it throws an error without a proper message if catalog is not created.

We need to throw an error with the proper message that the catalog is missing

## Related Issue
https://linear.app/ai-squared/issue/BE-72/raise-an-error-in-sync-stream-name-exists-if-catalog-is-not-present

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Connector (Destination or Source Connector)
- [ ] Breaking change (fix or feature that would impact existing functionality)
- [ ] Styling change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Chore

## How Has This Been Tested?
Tested using Rspec

## Checklist:

- [ ] Ensure a branch name is prefixed with `feature`, `bugfix`, `hotfix`, `release`, `style` or `chore` followed by `/` and branch name e.g `feature/add-salesforce-connector`
- [ ] Added unit tests for the changes made (if required)
- [ ] Have you made sure the commit messages meets the guidelines?
- [ ] Added relevant screenshots for the changes
- [ ] Have you tested the changes on local/staging?
- [ ] Added the new connector in rollout.rb
- [ ] Have you updated the version number of the gem?
- [ ] Have you ensured that your changes for new connector are documented in the [docs repo](https://github.com/Multiwoven/docs) or relevant documentation files?
- [ ] Have you updated the run time dependency in multiwoven-integrations.gemspec if new gems are added
- [ ] Have you made sure the code you have written follows the best practises to the best of your knowledge?
