### PR TITLE
fix: moved loop break after return variable for skipped rows

### DIFF
--- a/server/lib/reverse_etl/utils/batch_query.rb
+++ b/server/lib/reverse_etl/utils/batch_query.rb
@@ -13,7 +13,7 @@ module ReverseEtl
           # Set the current limit and offset in the sync configuration
           params[:sync_config].limit = params[:batch_size]
           params[:sync_config].offset = current_offset
-
+          
           if initial_sync_config.cursor_field.present?
             query_with_cursor = CursorQueryBuilder.build_cursor_query(initial_sync_config, last_cursor_field_value)
             params[:sync_config] = build_cursor_sync_config(params[:sync_config], query_with_cursor)
@@ -30,12 +30,11 @@ module ReverseEtl
           end
           # Increment the offset by the batch size for the next iteration
           current_offset += params[:batch_size]
-
-          break if result.empty?
-
           yield result, current_offset, last_cursor_field_value if block_given?
           # Break the loop if the number of records fetched is less than the batch size
           # break if result.size < params[:batch_size]
+
+          break if result.empty?
         end
       end
 

--- a/server/lib/reverse_etl/utils/batch_query.rb
+++ b/server/lib/reverse_etl/utils/batch_query.rb
@@ -13,7 +13,7 @@ module ReverseEtl
           # Set the current limit and offset in the sync configuration
           params[:sync_config].limit = params[:batch_size]
           params[:sync_config].offset = current_offset
-          
+
           if initial_sync_config.cursor_field.present?
             query_with_cursor = CursorQueryBuilder.build_cursor_query(initial_sync_config, last_cursor_field_value)
             params[:sync_config] = build_cursor_sync_config(params[:sync_config], query_with_cursor)
@@ -33,7 +33,6 @@ module ReverseEtl
           yield result, current_offset, last_cursor_field_value if block_given?
           # Break the loop if the number of records fetched is less than the batch size
           # break if result.size < params[:batch_size]
-
           break if result.empty?
         end
       end


### PR DESCRIPTION
## Description

<!-- A brief description of what this pull request does. Include the purpose of the change and any relevant context. e.g
 This PR enhances the process of data fetching in the application -->

## Related Issue

<!-- Link to any related issues or indicate 'None' if applicable e.g
 Relates to issue #123 - 'Enhance the process of fetching destinations details'. If none, state 'None'. -->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Connector (Destination or Source Connector)
- [ ] Breaking change (fix or feature that would impact existing functionality)
- [ ] Styling change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Chore

## How Has This Been Tested?

<!-- Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist:

- [x] Ensure a branch name is prefixed with `feature`, `bugfix`, `hotfix`, `release`, `style` or `chore` followed by `/` and branch name e.g `feature/add-salesforce-connector`
- [ ] Added unit tests for the changes made (if required)
- [x] Have you made sure the commit messages meets the guidelines?
- [x] Added relevant screenshots for the changes
- [x] Have you tested the changes on local/staging?
- [ ] Added the new connector in rollout.rb
- [ ] Have you updated the version number of the gem?
- [ ] Have you ensured that your changes for new connector are documented in the [docs repo](https://github.com/Multiwoven/docs) or relevant documentation files?
- [ ] Have you updated the run time dependency in multiwoven-integrations.gemspec if new gems are added
- [ ] Have you made sure the code you have written follows the best practises to the best of your knowledge?
