### PR TITLE
fix: clickhouse connector icon render

### DIFF
--- a/integrations/Gemfile.lock
+++ b/integrations/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 PATH
   remote: .
   specs:
-    multiwoven-integrations (0.1.68)
+    multiwoven-integrations (0.1.70)
       activesupport
       async-websocket
       aws-sdk-athena
@@ -133,6 +133,7 @@ GEM
       multipart-post (~> 2)
     faraday-net_http (3.0.2)
     ffi (1.16.3)
+    ffi (1.16.3-x64-mingw-ucrt)
     fiber-annotation (0.2.0)
     fiber-local (1.1.0)
       fiber-storage
@@ -205,6 +206,7 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.6)
+    pg (1.5.6-x64-mingw-ucrt)
     process_executer (1.1.0)
     public_suffix (5.0.5)
     racc (1.8.0)
@@ -303,6 +305,7 @@ GEM
 
 PLATFORMS
   x64-mingw-ucrt
+  x86_64-darwin-23
 
 DEPENDENCIES
   activesupport

--- a/integrations/lib/multiwoven/integrations/rollout.rb
+++ b/integrations/lib/multiwoven/integrations/rollout.rb
@@ -2,7 +2,7 @@
 
 module Multiwoven
   module Integrations
-    VERSION = "0.1.69"
+    VERSION = "0.1.70"
 
     ENABLED_SOURCES = %w[
       Snowflake

--- a/integrations/lib/multiwoven/integrations/source/clickhouse/icon.svg
+++ b/integrations/lib/multiwoven/integrations/source/clickhouse/icon.svg
@@ -1,4 +1,25 @@
-<svg height="2222" viewBox="0 0 9 8" width="2500" xmlns="http://www.w3.org/2000/svg">
-    <path d="m0 7h1v1h-1z" fill="#f00"/>
-    <path d="m0 0h1v7h-1zm2 0h1v8h-1zm2 0h1v8h-1zm2 0h1v8h-1zm2 3.25h1v1.5h-1z" fill="#fc0"/>
+<svg height="100" width="100" version="1.1" id="Layer_1" xmlns:x="ns_extend;" xmlns:i="ns_ai;" xmlns:graph="ns_graphs;" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 50.6 50.6" style="enable-background:new 0 0 50.6 50.6;" xml:space="preserve">
+ <metadata>
+  <sfw xmlns="ns_sfw;">
+   <slices>
+   </slices>
+      <sliceSourceBounds bottomLeftOrigin="true" height="50.6" width="50.6" x="0" y="0">
+   </sliceSourceBounds>
+  </sfw>
+ </metadata>
+    <g>
+  <g>
+   <path d="M0.6,0H5c0.3,0,0.6,0.3,0.6,0.6V50c0,0.3-0.3,0.6-0.6,0.6H0.6C0.3,50.6,0,50.4,0,50V0.6C0,0.3,0.3,0,0.6,0z" fill="yellow">
+   </path>
+      <path d="M11.8,0h4.4c0.3,0,0.6,0.3,0.6,0.6V50c0,0.3-0.3,0.6-0.6,0.6h-4.4c-0.3,0-0.6-0.3-0.6-0.6V0.6C11.3,0.3,11.5,0,11.8,0z" fill="yellow">
+   </path>
+      <path d="M23.1,0h4.4c0.3,0,0.6,0.3,0.6,0.6V50c0,0.3-0.3,0.6-0.6,0.6h-4.4c-0.3,0-0.6-0.3-0.6-0.6V0.6C22.5,0.3,22.8,0,23.1,0z" fill="yellow">
+   </path>
+      <path d="M34.3,0h4.4c0.3,0,0.6,0.3,0.6,0.6V50c0,0.3-0.3,0.6-0.6,0.6h-4.4c-0.3,0-0.6-0.3-0.6-0.6V0.6C33.7,0.3,34,0,34.3,0z" fill="yellow">
+   </path>
+      <path d="M45.6,19.7H50c0.3,0,0.6,0.3,0.6,0.6v10.1c0,0.3-0.3,0.6-0.6,0.6h-4.4c-0.3,0-0.6-0.3-0.6-0.6V20.3
+            C45,20,45.3,19.7,45.6,19.7z" fill="yellow">
+   </path>
+  </g>
+ </g>
 </svg>


### PR DESCRIPTION
## Description

Quick fix for clickhouse connector icon as it was not rendering

## Related Issue


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Connector (Destination or Source Connector)
- [ ] Breaking change (fix or feature that would impact existing functionality)
- [ ] Styling change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Chore

## How Has This Been Tested?

Localhost

## Checklist:

- [x] Ensure a branch name is prefixed with `feature`, `bugfix`, `hotfix`, `release`, `style` or `chore` followed by `/` and branch name e.g `feature/add-salesforce-connector`
- [ ] Added unit tests for the changes made (if required)
- [ ] Have you made sure the commit messages meets the guidelines?
- [ ] Added relevant screenshots for the changes
- [ ] Have you tested the changes on local/staging?
- [ ] Added the new connector in rollout.rb
- [ ] Have you updated the version number of the gem?
- [ ] Have you ensured that your changes for new connector are documented in the [docs repo](https://github.com/Multiwoven/docs) or relevant documentation files?
- [ ] Have you updated the run time dependency in multiwoven-integrations.gemspec if new gems are added
- [ ] Have you made sure the code you have written follows the best practises to the best of your knowledge?
