### PR TITLE
fix(EE): server ci set ubuntu to 22.04

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     services:
       postgres:


### PR DESCRIPTION
## Description

<!-- A brief description of what this pull request does. Include the purpose of the change and any relevant context. e.g
 This PR enhances the process of data fetching in the application -->

Sets runner ubuntu version to 22.04, not ubuntu-latest.

## Related Issue

<!-- Link to any related issues or indicate 'None' if applicable e.g
 Relates to issue #123 - 'Enhance the process of fetching destinations details'. If none, state 'None'. -->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Connector (Destination or Source Connector)
- [ ] Breaking change (fix or feature that would impact existing functionality)
- [ ] Styling change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Chore

## How Has This Been Tested?

<!-- Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist:

- [ ] Ensure a branch name is prefixed with `feature`, `bugfix`, `hotfix`, `release`, `style` or `chore` followed by `/` and branch name e.g `feature/add-salesforce-connector`
- [ ] Added unit tests for the changes made (if required)
- [ ] Have you made sure the commit messages meets the guidelines?
- [ ] Added relevant screenshots for the changes
- [ ] Have you tested the changes on local/staging?
- [ ] Added the new connector in rollout.rb
- [ ] Have you updated the version number of the gem?
- [ ] Have you ensured that your changes for new connector are documented in the [docs repo](https://github.com/Multiwoven/docs) or relevant documentation files?
- [ ] Have you updated the run time dependency in multiwoven-integrations.gemspec if new gems are added
- [ ] Have you made sure the code you have written follows the best practises to the best of your knowledge?
