### PR TITLE
Docs: update README docker compose syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ cp .env ui/.env
 6. **Start the services:**
 
 ```bash
-docker-compose build && docker-compose up
+docker compose build && docker compose up
 ```
 
 UI can be accessed at the PORT 8000 :


### PR DESCRIPTION
The modern syntax for running docker compose is `docker compose up` not `docker-compose up`

## Type of Change

-  Documentation update
