### PR TITLE
fix(CE): stabilize local docker startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ cd multiwoven
 3. **Initialize .env file:**
 
 ```bash
-mv .env.example .env
+cp server/.env.example .env
 ```
 
 4. **Copy .env file to ui folder:**
@@ -137,7 +137,7 @@ cp .env ui/.env
 6. **Start the services:**
 
 ```bash
-docker-compose build && docker-compose up
+docker compose up --build
 ```
 
 UI can be accessed at the PORT 8000 :
@@ -145,6 +145,14 @@ UI can be accessed at the PORT 8000 :
 ```bash
 http://localhost:8000
 ```
+
+The backend API runs on port 3000:
+
+```bash
+http://localhost:3000
+```
+
+If you run only the frontend from `ui/`, you still need the backend running locally on port 3000.
 
 For more details, check out the local [deployment guide](https://docs.squared.ai/deployment-and-security/setup/docker-compose-dev) in the documentation.
 

--- a/README.md
+++ b/README.md
@@ -152,8 +152,6 @@ The backend API runs on port 3000:
 http://localhost:3000
 ```
 
-If you run only the frontend from `ui/`, you still need the backend running locally on port 3000.
-
 For more details, check out the local [deployment guide](https://docs.squared.ai/deployment-and-security/setup/docker-compose-dev) in the documentation.
 
 ### Self-hosted Options

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       - 8080:8080
   # This section is for the Multiwoven services Backend and Frontend
   db:
-    image: postgres:latest
+    image: postgres:16
     environment:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_USER: ${DB_USERNAME}
@@ -64,6 +64,7 @@ services:
       dockerfile: Dockerfile
       args:
         TARGETARCH: ${TARGETARCH:-amd64}
+    restart: unless-stopped
     ports:
       - "3000:3000"
     depends_on:
@@ -84,6 +85,7 @@ services:
     build:
       context: ./server
       dockerfile: Dockerfile
+    restart: unless-stopped
     depends_on:
       - db
       - redis

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       - 8080:8080
   # Multiwoven services
   db:
-    image: postgres:latest
+    image: postgres:16
     environment:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_USER: ${DB_USERNAME}
@@ -64,6 +64,7 @@ services:
       dockerfile: Dockerfile.dev
       args:
         TARGETARCH: ${TARGETARCH:-amd64}
+    restart: unless-stopped
     ports:
       - "3000:3000"
     depends_on:
@@ -80,6 +81,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
+    restart: unless-stopped
     depends_on:
       - db
       - redis

--- a/ui/README.md
+++ b/ui/README.md
@@ -75,7 +75,7 @@ npm i
 4. **Initialize .env file:**
 
 ```bash
-mv .env.example .env
+cp ../server/.env.example .env
 ```
 
 4. **Start the services:**
@@ -92,6 +92,7 @@ http://localhost:8000
 
 Note: In the env, the base URL for the mutiwoven server is pointing to the staging deployed URL. If you want it to point to the local server, you will have to make sure the multiwoven server is setup locally on your machine.
 Follow the steps [here](https://github.com/Multiwoven/multiwoven-server/tree/main?tab=readme-ov-file#local-setup) to set it up locally.
+The local UI expects the backend at `http://localhost:3000`.
 
 ## Contributing
 


### PR DESCRIPTION
## Description

Hey folks, I got issues with my first local deployment attempt, so I decided to open a PR with what fixed it for me.

- pin the local app database image to PostgreSQL 16 to avoid `postgres:latest` volume compatibility breakage
- restart the server and worker during local boot races so they recover when Postgres or Temporal are not ready on first boot
- fix the local setup docs where they point to missing env files

## Related Issue

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## How Has This Been Tested?

- Ran `docker compose up --build` locally from the repo root
- Verified the backend responded on `http://localhost:3000`
- Verified the UI responded on `http://localhost:8000`
- Signed up and logged in locally after the stack came up


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated local setup instructions for environment file initialization and Docker Compose startup commands
  * Clarified backend API endpoint and port configuration for local development

* **Chores**
  * Updated Docker Compose configurations with pinned PostgreSQL version
  * Added automatic restart policies to improve service reliability
  * Adjusted volume configuration definitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->