### PR TITLE
feat(hubspot): discover + upsert custom objects; fix(bigquery) discover nil guard

### DIFF
--- a/integrations/lib/multiwoven/integrations/destination/hubspot/client.rb
+++ b/integrations/lib/multiwoven/integrations/destination/hubspot/client.rb
@@ -23,8 +23,9 @@ module Multiwoven
             failure_status(e)
           end
 
-          def discover(_connection_config = nil)
+          def discover(connection_config = nil)
             catalog = build_catalog(load_catalog)
+            append_custom_object_streams(catalog, connection_config) if connection_config
             catalog.to_multiwoven_message
           rescue StandardError => e
             handle_exception(e, {
@@ -61,7 +62,7 @@ module Multiwoven
             properties = stream.json_schema.with_indifferent_access[:properties]
             records.each do |record_object|
               record = extract_data(record_object, properties)
-              request, response = *send_data_to_hubspot(stream.name, record)
+              request, response = *send_data_to_hubspot(stream, record)
               write_success += 1
               log_message_array << log_request_response("info", request, response)
             rescue StandardError => e
@@ -77,12 +78,40 @@ module Multiwoven
             tracking_message(write_success, write_failure, log_message_array)
           end
 
-          def send_data_to_hubspot(stream_name, record = {})
-            args = build_args(@action, stream_name, record)
-            hubspot_stream = @client.crm.send(stream_name)
+          def send_data_to_hubspot(stream, record = {})
+            schema = stream.json_schema.with_indifferent_access
+            object_type = schema[:hubspot_object_type]
+            return upsert_custom_object(object_type, schema[:external_id_property], record) if object_type
+
+            args = build_args(@action, stream.name, record)
+            hubspot_stream = @client.crm.send(stream.name)
             hubspot_data = { simple_public_object_input_for_create: args }
             response = hubspot_stream.basic_api.send(@action, hubspot_data)
             [args, response]
+          end
+
+          # Custom objects are unreachable through `crm.send(stream_name)` (no such method);
+          # they must go through the generic `crm.objects` API, keyed by object_type id.
+          # gem 17.2.0 has no batch upsert-by-idProperty, so we upsert per record:
+          # update by the unique external-id property, and create on a 404.
+          def upsert_custom_object(object_type, external_id_property, record)
+            input = { properties: record[:properties] || record }
+            external_id = external_id_property && input[:properties] && input[:properties][external_id_property]
+
+            if external_id_property && !external_id.to_s.empty?
+              begin
+                response = @client.crm.objects.basic_api.update(
+                  object_type, external_id.to_s, input, id_property: external_id_property
+                )
+                return [input, response]
+              rescue ::Hubspot::Crm::Objects::ApiError => e
+                raise unless e.code == 404
+                # Not found by external id → fall through and create it.
+              end
+            end
+
+            response = @client.crm.objects.basic_api.create(object_type, input)
+            [input, response]
           end
 
           def build_args(action, stream_name, record)
@@ -110,6 +139,75 @@ module Multiwoven
 
           def load_catalog
             read_json(CATALOG_SPEC_PATH)
+          end
+
+          # Discover the portal's custom objects and expose one stream per object,
+          # alongside the static standard streams. Failure here must not break the
+          # discovery of the standard objects, so it is rescued and logged.
+          def append_custom_object_streams(catalog, connection_config)
+            initialize_client(connection_config.with_indifferent_access)
+            schemas = @client.crm.schemas.core_api.get_all.results || []
+            schemas.each do |schema|
+              catalog.streams << build_stream(custom_object_stream(schema))
+            end
+          rescue StandardError => e
+            log_debug("HUBSPOT:CRM:DISCOVER:CUSTOM_OBJECTS:SKIPPED #{e.message}")
+          end
+
+          def custom_object_stream(schema)
+            {
+              "name" => schema.name,
+              # "update" is a placeholder kept within the StreamAction enum; the real
+              # upsert (update-by-external-id, create on 404) lives in #upsert_custom_object,
+              # which is selected by the presence of hubspot_object_type, not by this action.
+              "action" => "update",
+              "json_schema" => custom_object_json_schema(schema),
+              "supported_sync_modes" => %w[incremental],
+              "batch_support" => false,
+              "batch_size" => 1
+            }
+          end
+
+          # hubspot_object_type and external_id_property are carried INSIDE json_schema
+          # on purpose: build_stream and the server's stream_to_protocol both drop
+          # unknown top-level stream keys, but json_schema is a free-form hash that
+          # survives the round-trip back to #write.
+          def custom_object_json_schema(schema)
+            object_properties = Array(schema.properties).each_with_object({}) do |property, acc|
+              acc[property.name] = { "type" => json_type_for(property.type) }
+            end
+            {
+              "$schema" => "http://json-schema.org/draft-07/schema#",
+              "title" => schema.labels&.singular || schema.name,
+              "type" => "object",
+              "hubspot_object_type" => schema.object_type_id,
+              "external_id_property" => detect_external_id_property(schema),
+              "properties" => {
+                "properties" => {
+                  "type" => "object",
+                  "properties" => object_properties,
+                  "additionalProperties" => { "type" => %w[string number boolean] }
+                }
+              }
+            }
+          end
+
+          # The match key for upsert: the property flagged unique in HubSpot. When a
+          # schema has several, prefer one that is also required (the canonical id).
+          def detect_external_id_property(schema)
+            unique = Array(schema.properties).select(&:has_unique_value)
+            return if unique.empty?
+
+            required = Array(schema.required_properties)
+            (unique.find { |property| required.include?(property.name) } || unique.first).name
+          end
+
+          def json_type_for(hubspot_type)
+            case hubspot_type
+            when "number" then "number"
+            when "bool" then "boolean"
+            else "string"
+            end
           end
 
           def log_debug(message)

--- a/integrations/lib/multiwoven/integrations/destination/hubspot/config/spec.json
+++ b/integrations/lib/multiwoven/integrations/destination/hubspot/config/spec.json
@@ -1,6 +1,6 @@
 {
   "documentation_url": "https://docs.squared.ai/guides/destinations/retl-destinations/crm/hubspot",
-  "stream_type": "static",
+  "stream_type": "dynamic",
   "connection_specification": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "HubSpot CRM",

--- a/integrations/lib/multiwoven/integrations/source/bigquery/client.rb
+++ b/integrations/lib/multiwoven/integrations/source/bigquery/client.rb
@@ -20,10 +20,16 @@ module Multiwoven::Integrations::Source
         bigquery = create_connection(connection_config)
         target_dataset_id = connection_config["dataset_id"]
         records = bigquery.datasets.flat_map do |dataset|
-          next unless dataset.dataset_id == target_dataset_id
+          # Return [] (not nil) for non-target datasets: a nil from flat_map would
+          # leak into `records` and blow up group_by_table with `[] for nil`.
+          next [] unless dataset.dataset_id == target_dataset_id
 
           dataset.tables.flat_map do |table|
-            table.schema.fields.map do |field|
+            # Views / external tables can expose a nil schema — skip them gracefully.
+            fields = table.schema&.fields
+            next [] if fields.nil?
+
+            fields.map do |field|
               {
                 table_name: table.table_id,
                 column_name: field.name,
@@ -32,7 +38,7 @@ module Multiwoven::Integrations::Source
               }
             end
           end
-        end
+        end.compact
         catalog = Catalog.new(streams: create_streams(records))
         catalog.to_multiwoven_message
       rescue StandardError => e

--- a/integrations/spec/multiwoven/integrations/destination/hubspot/client_spec.rb
+++ b/integrations/spec/multiwoven/integrations/destination/hubspot/client_spec.rb
@@ -149,6 +149,105 @@ RSpec.describe Multiwoven::Integrations::Destination::Hubspot::Client do
     end
   end
 
+  describe "#discover with custom objects" do
+    let(:unique_property) { double(name: "user_uuid", type: "string", has_unique_value: true) }
+    let(:other_property) { double(name: "nom_du_compte", type: "string", has_unique_value: false) }
+    let(:custom_schema) do
+      double(
+        name: "comptes_lpl",
+        object_type_id: "2-12345678",
+        labels: double(singular: "Compte LPL"),
+        required_properties: ["user_uuid"],
+        properties: [unique_property, other_property]
+      )
+    end
+
+    def stub_schemas(schemas)
+      core_api = double
+      allow(core_api).to receive(:get_all).and_return(double(results: schemas))
+      hubspot_client = double
+      allow(hubspot_client).to receive(:crm).and_return(double(schemas: double(core_api: core_api)))
+      allow(::Hubspot::Client).to receive(:new).and_return(hubspot_client)
+    end
+
+    it "appends one stream per custom object carrying object type and external id in json_schema" do
+      stub_schemas([custom_schema])
+
+      catalog = client.discover(connection_config).catalog
+      custom = catalog.streams.find { |stream| stream.name == "comptes_lpl" }
+
+      expect(custom).not_to be_nil
+      expect(custom.json_schema["hubspot_object_type"]).to eq("2-12345678")
+      expect(custom.json_schema["external_id_property"]).to eq("user_uuid")
+      expect(custom.json_schema["properties"]["properties"]["properties"]).to have_key("user_uuid")
+      # standard streams are still present
+      expect(catalog.streams.map(&:name)).to include("contacts")
+    end
+
+    it "still returns the standard streams when schema listing fails" do
+      hubspot_client = double
+      allow(hubspot_client).to receive(:crm).and_raise(StandardError.new("boom"))
+      allow(::Hubspot::Client).to receive(:new).and_return(hubspot_client)
+
+      catalog = client.discover(connection_config).catalog
+      expect(catalog.streams.map(&:name)).to include("contacts")
+    end
+  end
+
+  describe "#write to a custom object" do
+    let(:custom_object_schema) do
+      {
+        "type" => "object",
+        "hubspot_object_type" => "2-12345678",
+        "external_id_property" => "user_uuid",
+        "properties" => {
+          "properties" => {
+            "type" => "object",
+            "properties" => { "user_uuid" => { "type" => "string" }, "nom_du_compte" => { "type" => "string" } }
+          }
+        }
+      }
+    end
+    let(:custom_sync_config_json) do
+      sync_config_json.merge(
+        "stream" => {
+          "name" => "comptes_lpl",
+          "action" => "update",
+          "request_rate_limit" => 4,
+          "rate_limit_unit_seconds" => 1,
+          "json_schema" => custom_object_schema
+        }
+      ).with_indifferent_access
+    end
+    let(:custom_sync_config) do
+      Multiwoven::Integrations::Protocol::SyncConfig.from_json(custom_sync_config_json.to_json)
+    end
+    let(:custom_records) { [{ "properties" => { "user_uuid" => "uuid-1", "nom_du_compte" => "Alice" } }] }
+
+    it "updates an existing record by its external id property" do
+      update = stub_request(:patch, "https://api.hubapi.com/crm/v3/objects/2-12345678/uuid-1?idProperty=user_uuid")
+               .to_return(status: 200, body: "{}", headers: {})
+
+      response = client.write(custom_sync_config, custom_records)
+
+      expect(response.tracking.success).to eq(1)
+      expect(response.tracking.failed).to eq(0)
+      expect(update).to have_been_requested
+    end
+
+    it "creates the record when the external id is not found (404)" do
+      stub_request(:patch, "https://api.hubapi.com/crm/v3/objects/2-12345678/uuid-1?idProperty=user_uuid")
+        .to_return(status: 404, body: "{}", headers: {})
+      create = stub_request(:post, "https://api.hubapi.com/crm/v3/objects/2-12345678")
+               .to_return(status: 201, body: "{}", headers: {})
+
+      response = client.write(custom_sync_config, custom_records)
+
+      expect(response.tracking.success).to eq(1)
+      expect(create).to have_been_requested
+    end
+  end
+
   describe "#meta_data" do
     it "serves it github image url as icon" do
       image_url = "https://raw.githubusercontent.com/Multiwoven/multiwoven/main/integrations/lib/multiwoven/integrations/destination/hubspot/icon.svg"

--- a/integrations/spec/multiwoven/integrations/source/bigquery/client_spec.rb
+++ b/integrations/spec/multiwoven/integrations/source/bigquery/client_spec.rb
@@ -99,6 +99,45 @@ RSpec.describe Multiwoven::Integrations::Source::Bigquery::Client do
       expect(first_stream.json_schema["properties"]).to eq({ "FullName" => { "type" => "string" } })
     end
 
+    it "skips datasets other than the target without crashing" do
+      other_dataset = instance_double(Google::Cloud::Bigquery::Dataset)
+      allow(other_dataset).to receive(:dataset_id).and_return("not_profile")
+
+      allow(Google::Cloud::Bigquery).to receive(:new).and_return(bigquery_instance)
+      # Non-target dataset listed first: it must not leak a nil into the records.
+      allow(bigquery_instance).to receive(:datasets).and_return([other_dataset, bigquery_dataset])
+      allow(bigquery_dataset).to receive(:dataset_id).and_return("profile")
+      allow(bigquery_dataset).to receive(:tables).and_return([bigquery_table])
+      allow(bigquery_table).to receive(:table_id).and_return("customer")
+      allow(bigquery_table).to receive(:schema).and_return(bigquery_schema)
+      allow(bigquery_schema).to receive(:fields).and_return([bigquery_field])
+      allow(bigquery_field).to receive(:name).and_return("FullName")
+      allow(bigquery_field).to receive(:type).and_return("string")
+      allow(bigquery_field).to receive(:mode).and_return("NULLABLE")
+
+      message = client.discover(sync_config[:source][:connection_specification].with_indifferent_access)
+      expect(message.catalog.streams.map(&:name)).to eq(["customer"])
+    end
+
+    it "skips tables with a nil schema (e.g. views) without crashing" do
+      view_table = instance_double(Google::Cloud::Bigquery::Table)
+      allow(view_table).to receive(:schema).and_return(nil)
+
+      allow(Google::Cloud::Bigquery).to receive(:new).and_return(bigquery_instance)
+      allow(bigquery_instance).to receive(:datasets).and_return([bigquery_dataset])
+      allow(bigquery_dataset).to receive(:dataset_id).and_return("profile")
+      allow(bigquery_dataset).to receive(:tables).and_return([view_table, bigquery_table])
+      allow(bigquery_table).to receive(:table_id).and_return("customer")
+      allow(bigquery_table).to receive(:schema).and_return(bigquery_schema)
+      allow(bigquery_schema).to receive(:fields).and_return([bigquery_field])
+      allow(bigquery_field).to receive(:name).and_return("FullName")
+      allow(bigquery_field).to receive(:type).and_return("string")
+      allow(bigquery_field).to receive(:mode).and_return("NULLABLE")
+
+      message = client.discover(sync_config[:source][:connection_specification].with_indifferent_access)
+      expect(message.catalog.streams.map(&:name)).to eq(["customer"])
+    end
+
     it "discover schema failure" do
       allow(client).to receive(:create_connection).and_raise(StandardError.new("test error"))
       expect(client).to receive(:handle_exception).with(


### PR DESCRIPTION
## Contexte

Fork LPL de Multiwoven pour la migration Hightouch → Multiwoven (BigQuery → HubSpot).
Le connecteur destination HubSpot d'origine ne savait écrire que vers les 4 objets standards
(`crm.send(stream_name)`) et le discover BigQuery plantait dès qu'un autre dataset existait —
ce qui rendait 4 des 6 syncs LPL inmigrables et bloquait la création des Models.

Cette PR porte les deux premiers correctifs du plan (capacité 1 « objets custom » + déblocage discover).

## Changements

### `fix(bigquery)`: discover robuste aux nil
- Cause : pour chaque dataset **non ciblé**, `next unless ...` renvoyait `nil` dans le `flat_map`,
  polluant `records` → `group_by_table` plantait avec `undefined method '[]' for nil`.
  Les vues / tables externes (schéma `nil`) déclenchaient la même classe de bug.
- Fix : `next []` pour les datasets non ciblés, garde `table.schema&.fields` pour les vues, `.compact`.
- Tests de régression : dataset non-cible listé en premier ; table à schéma nil.

### `feat(hubspot)`: discover + upsert des objets custom
- **Discover dynamique** : `crm.schemas.core_api.get_all` → un stream par objet custom, ajouté aux
  streams standards. Chaque stream custom porte `hubspot_object_type` (objectTypeId) et
  `external_id_property` (propriété `hasUniqueValue`, en préférant une requise) **dans son
  `json_schema`** — seul canal qui survit à `build_stream` et au `stream_to_protocol` du serveur,
  jusqu'au `#write`. Fallback gracieux sur les streams standards si le listing échoue.
- **Write upsert** : pour un objet custom, passage par l'API générique `crm.objects` —
  `basic_api.update(object_type, ext_id, input, id_property:)`, puis `create` sur 404. Per-record
  (gem 17.2.0 sans batch upsert-by-idProperty ; le batch viendra plus tard). Chemin sélectionné par
  la présence de `hubspot_object_type` → **comportement des objets standards inchangé**.
- `spec.json` : `stream_type` → `dynamic` (l'UI lance le discover).
- Tests : discovery dynamique (+ fallback), et chemins upsert update / create-on-404.

## Notes

- **Sans bump du gem** `hubspot-api-client` (reste 17.2.0) ni modification de l'enum partagé
  `StreamAction` : l'`action` du stream custom reste `"update"`, l'upsert réel vit dans le connecteur.
- La suite RSpec ne tourne pas en local sur macOS arm64 (la lib charge `ruby-oci8`/`odbc` en eager ;
  la CI installe Oracle Instant Client sous Linux) → validée ici par syntaxe + revue de logique,
  **exécution réelle attendue de cette CI**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HubSpot connector now discovers and syncs to custom objects with automatic schema-aware mapping and upsert capabilities
  * Dynamic stream discovery enabled for HubSpot connector

* **Bug Fixes**
  * Improved BigQuery source discovery reliability by safely handling edge cases including views and external tables with missing or incomplete schemas

<!-- end of auto-generated comment: release notes by coderabbit.ai -->